### PR TITLE
chore: enable arm64 images, disable arm/v7 builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-07-03T16:11:24Z by kres latest.
+# Generated on 2023-07-07T11:40:16Z by kres latest.
 
 kind: pipeline
 type: kubernetes
@@ -169,6 +169,7 @@ steps:
       from_secret: ghcr_token
     GHCR_USERNAME:
       from_secret: ghcr_username
+    PLATFORM: linux/amd64,linux/arm64
     PUSH: true
   volumes:
   - name: outer-docker-socket
@@ -185,36 +186,6 @@ steps:
       - pull_request
   depends_on:
   - image-kube-service-exposer
-
-- name: push-kube-service-exposer-latest
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - docker login ghcr.io --username "$${GHCR_USERNAME}" --password "$${GHCR_PASSWORD}"
-  - make image-kube-service-exposer TAG=latest
-  environment:
-    GHCR_PASSWORD:
-      from_secret: ghcr_token
-    GHCR_USERNAME:
-      from_secret: ghcr_username
-    PUSH: true
-  volumes:
-  - name: outer-docker-socket
-    path: /var/outer-run
-  - name: docker-socket
-    path: /var/run
-  - name: buildx
-    path: /root/.docker/buildx
-  - name: ssh
-    path: /root/.ssh
-  when:
-    branch:
-    - main
-    event:
-      exclude:
-      - pull_request
-  depends_on:
-  - push-kube-service-exposer
 
 - name: release-notes
   pull: always

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -1,4 +1,11 @@
 ---
+kind: common.Image
+name: image-kube-service-exposer
+spec:
+  pushLatest: false
+  droneExtraEnvironment:
+    PLATFORM: linux/amd64,linux/arm64
+---
 kind: golang.Build
 spec:
   outputs:
@@ -8,7 +15,3 @@ spec:
     linux-arm64:
       GOOS: linux
       GOARCH: arm64
-    linux-armv7:
-      GOOS: linux
-      GOARCH: arm
-      GOARM: 7

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-07-04T16:48:30Z by kres latest.
+# Generated on 2023-07-07T11:40:16Z by kres latest.
 
 ARG TOOLCHAIN
 
@@ -81,17 +81,6 @@ ARG SHA
 ARG TAG
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOARCH=arm64 GOOS=linux go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS} -X ${VERSION_PKG}.Name=kube-service-exposer -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /kube-service-exposer-linux-arm64
 
-# builds kube-service-exposer-linux-armv7
-FROM base AS kube-service-exposer-linux-armv7-build
-COPY --from=generate / /
-WORKDIR /src/cmd/kube-service-exposer
-ARG GO_BUILDFLAGS
-ARG GO_LDFLAGS
-ARG VERSION_PKG="github.com/siderolabs/kube-service-exposer/internal/version"
-ARG SHA
-ARG TAG
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOARCH=arm GOARM=7 GOOS=linux go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS} -X ${VERSION_PKG}.Name=kube-service-exposer -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /kube-service-exposer-linux-armv7
-
 # runs gofumpt
 FROM base AS lint-gofumpt
 RUN FILES="$(gofumpt -l .)" && test -z "${FILES}" || (echo -e "Source code is not formatted with 'gofumpt -w .':\n${FILES}"; exit 1)
@@ -130,9 +119,6 @@ COPY --from=kube-service-exposer-linux-amd64-build /kube-service-exposer-linux-a
 FROM scratch AS kube-service-exposer-linux-arm64
 COPY --from=kube-service-exposer-linux-arm64-build /kube-service-exposer-linux-arm64 /kube-service-exposer-linux-arm64
 
-FROM scratch AS kube-service-exposer-linux-armv7
-COPY --from=kube-service-exposer-linux-armv7-build /kube-service-exposer-linux-armv7 /kube-service-exposer-linux-armv7
-
 FROM scratch AS unit-tests
 COPY --from=unit-tests-run /src/coverage.txt /coverage-unit-tests.txt
 
@@ -141,7 +127,6 @@ FROM kube-service-exposer-linux-${TARGETARCH} AS kube-service-exposer
 FROM scratch AS kube-service-exposer-all
 COPY --from=kube-service-exposer-linux-amd64 / /
 COPY --from=kube-service-exposer-linux-arm64 / /
-COPY --from=kube-service-exposer-linux-armv7 / /
 
 FROM scratch AS image-kube-service-exposer
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-07-04T16:48:30Z by kres latest.
+# Generated on 2023-07-07T11:40:16Z by kres latest.
 
 # common variables
 
 SHA := $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG := $(shell git describe --tag --always --dirty)
+ABBREV_TAG := $(shell git describe --tags >/dev/null 2>/dev/null && git describe --tag --always --match v[0-9]\* --abbrev=0 || echo 'undefined')
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 ARTIFACTS := _out
 WITH_DEBUG ?= false
@@ -18,10 +19,10 @@ GRPC_GO_VERSION ?= 1.3.0
 GRPC_GATEWAY_VERSION ?= 2.16.0
 VTPROTOBUF_VERSION ?= 0.4.0
 DEEPCOPY_VERSION ?= v0.5.5
-GOLANGCILINT_VERSION ?= v1.53.2
+GOLANGCILINT_VERSION ?= v1.53.3
 GOFUMPT_VERSION ?= v0.5.0
 GO_VERSION ?= 1.20
-GOIMPORTS_VERSION ?= v0.9.3
+GOIMPORTS_VERSION ?= v0.11.0
 GO_BUILDFLAGS ?=
 GO_LDFLAGS ?=
 CGO_ENABLED ?= 0
@@ -43,6 +44,7 @@ COMMON_ARGS += --push=$(PUSH)
 COMMON_ARGS += --build-arg=ARTIFACTS="$(ARTIFACTS)"
 COMMON_ARGS += --build-arg=SHA="$(SHA)"
 COMMON_ARGS += --build-arg=TAG="$(TAG)"
+COMMON_ARGS += --build-arg=ABBREV_TAG="$(ABBREV_TAG)"
 COMMON_ARGS += --build-arg=USERNAME="$(USERNAME)"
 COMMON_ARGS += --build-arg=REGISTRY="$(REGISTRY)"
 COMMON_ARGS += --build-arg=TOOLCHAIN="$(TOOLCHAIN)"
@@ -166,15 +168,8 @@ $(ARTIFACTS)/kube-service-exposer-linux-arm64:
 .PHONY: kube-service-exposer-linux-arm64
 kube-service-exposer-linux-arm64: $(ARTIFACTS)/kube-service-exposer-linux-arm64  ## Builds executable for kube-service-exposer-linux-arm64.
 
-.PHONY: $(ARTIFACTS)/kube-service-exposer-linux-armv7
-$(ARTIFACTS)/kube-service-exposer-linux-armv7:
-	@$(MAKE) local-kube-service-exposer-linux-armv7 DEST=$(ARTIFACTS)
-
-.PHONY: kube-service-exposer-linux-armv7
-kube-service-exposer-linux-armv7: $(ARTIFACTS)/kube-service-exposer-linux-armv7  ## Builds executable for kube-service-exposer-linux-armv7.
-
 .PHONY: kube-service-exposer
-kube-service-exposer: kube-service-exposer-linux-amd64 kube-service-exposer-linux-arm64 kube-service-exposer-linux-armv7  ## Builds executables for kube-service-exposer.
+kube-service-exposer: kube-service-exposer-linux-amd64 kube-service-exposer-linux-arm64  ## Builds executables for kube-service-exposer.
 
 .PHONY: lint-markdown
 lint-markdown:  ## Runs markdownlint.


### PR DESCRIPTION
Build container image for `linux/arm64` as well as `linux/amd64`.

Remove `linux/arm/v7` from Go builds.