### PR TITLE
feat: add more debug logs, rework logging

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-06-30T12:48:19Z by kres latest.
+# Generated on 2026-04-23T11:51:42Z by kres 8299790.
 
 codecov:
   require_ci_to_pass: false
@@ -9,7 +9,7 @@ coverage:
   status:
     project:
       default:
-        target: 50%
+        target: 40%
         threshold: 0.5%
         base: auto
         if_ci_failed: success

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -25,3 +25,7 @@ name: release
 spec:
   artifacts:
     - kube-service-exposer-*
+---
+kind: service.CodeCov
+spec:
+  targetThreshold: 40

--- a/cmd/kube-service-exposer/main.go
+++ b/cmd/kube-service-exposer/main.go
@@ -63,9 +63,9 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("failed to create logger: %w", err)
 		}
 
-		controllerruntimelog.SetLogger(zapr.NewLogger(logger))
+		controllerruntimelog.SetLogger(zapr.NewLogger(logger.Named("runtime")))
 
-		exposer, err := exposer.New(rootCmdArgs.annotationKey, rootCmdArgs.bindCIDRs, rootCmdArgs.disallowedHostPortRanges, logger.With(zap.String("component", "exposer")))
+		exposer, err := exposer.New(rootCmdArgs.annotationKey, rootCmdArgs.bindCIDRs, rootCmdArgs.disallowedHostPortRanges, logger.Named("exposer"))
 		if err != nil {
 			return err
 		}
@@ -78,7 +78,7 @@ var rootCmd = &cobra.Command{
 
 		if rootCmdArgs.pprofBindAddr != "" {
 			eg.Go(func() error {
-				return runPprofServer(ctx, logger)
+				return runPprofServer(ctx, logger.Named("pprof-server"))
 			})
 		}
 

--- a/internal/exposer/exposer.go
+++ b/internal/exposer/exposer.go
@@ -61,22 +61,22 @@ func New(annotationKey string, bindCIDRs, disallowedHostPortRanges []string, log
 		return nil, fmt.Errorf("failed to create ipSetMemoizer: %w", err)
 	}
 
-	ipSetProvider, err := NewFilteringIPSetProvider(bindCIDRs, ipSetMemoizer, logger)
+	ipSetProvider, err := NewFilteringIPSetProvider(bindCIDRs, ipSetMemoizer, logger.Named("ip-set-provider"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ipSetProvider: %w", err)
 	}
 
-	ipMapper, err := ip.NewMapper(ipSetProvider, &ip.TCPLoadBalancerProvider{}, logger.With(zap.String("component", "ip-mapper")))
+	ipMapper, err := ip.NewMapper(ipSetProvider, &ip.TCPLoadBalancerProvider{}, logger.Named("ip-mapper"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ipMapper: %w", err)
 	}
 
-	serviceHandler, err := service.NewHandler(annotationKey, ipMapper, disallowedHostPortRanges, logger.With(zap.String("component", "service-handler")))
+	serviceHandler, err := service.NewHandler(annotationKey, ipMapper, disallowedHostPortRanges, logger.Named("service-handler"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create serviceHandler: %w", err)
 	}
 
-	rec, err := reconciler.New(mgr, serviceHandler)
+	rec, err := reconciler.New(mgr, serviceHandler, logger.Named("reconciler"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reconciler: %w", err)
 	}
@@ -132,7 +132,7 @@ func (e *Exposer) Run(ctx context.Context) error {
 	if len(e.bindCIDRs) > 0 {
 		e.logger.Info("bindCIDRs are specified, start IP change listener")
 
-		ipTracker, err := ip.NewTracker(e.ipSetMemoizer, e.manager, e.serviceHandler, 30*time.Second, nil, e.logger.With(zap.String("component", "ip-tracker")))
+		ipTracker, err := ip.NewTracker(e.ipSetMemoizer, e.manager, e.serviceHandler, 30*time.Second, nil, e.logger.Named("ip-tracker"))
 		if err != nil {
 			return fmt.Errorf("failed to create ipTracker: %w", err)
 		}

--- a/internal/exposer/ip.go
+++ b/internal/exposer/ip.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/netip"
 
+	"github.com/siderolabs/gen/maps"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/kube-service-exposer/internal/cidrs"
@@ -29,6 +30,10 @@ type FilteringIPSetProvider struct {
 
 // NewFilteringIPSetProvider returns a new FilteringIPSetProvider.
 func NewFilteringIPSetProvider(bindCIDRs []string, underlyingProvider IPSetProvider, logger *zap.Logger) (*FilteringIPSetProvider, error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
 	bindCIDRPrefixes := make([]netip.Prefix, 0, len(bindCIDRs))
 
 	for _, bindCIDR := range bindCIDRs {
@@ -56,15 +61,25 @@ func NewFilteringIPSetProvider(bindCIDRs []string, underlyingProvider IPSetProvi
 // It returns the set of host IP addresses to bind the load balancer to.
 func (e *FilteringIPSetProvider) Get() (map[string]struct{}, error) {
 	if len(e.bindCIDRPrefixes) == 0 {
+		e.logger.Debug("no bind CIDRs configured, use wildcard IP")
+
 		return map[string]struct{}{"0.0.0.0": {}}, nil
 	}
 
 	allIPsSet, err := e.ipCache.Get()
 	if err != nil {
+		e.logger.Info("failed to get all IP addresses", zap.Error(err))
+
 		return nil, fmt.Errorf("failed to get all IP addresses: %w", err)
 	}
 
-	return cidrs.FilterIPSet(e.bindCIDRPrefixes, allIPsSet, func(ip string, err error) {
-		e.logger.Debug("failed to parse IP address", zap.String("ip", ip), zap.Error(err))
-	}), nil
+	e.logger.Debug("filter host IP set", zap.Int("ip-count", len(allIPsSet)))
+
+	filteredIPs := cidrs.FilterIPSet(e.bindCIDRPrefixes, allIPsSet, func(ip string, err error) {
+		e.logger.Info("failed to parse IP address", zap.String("ip", ip), zap.Error(err))
+	})
+
+	e.logger.Debug("filtered host IP set", zap.Int("ip-count", len(filteredIPs)), zap.Strings("ips", maps.Keys(filteredIPs)))
+
+	return filteredIPs, nil
 }

--- a/internal/ip/mapper.go
+++ b/internal/ip/mapper.go
@@ -86,23 +86,40 @@ func (m *Mapper) Add(svcName string, hostPort, svcPort int) error {
 
 	hostIPSet, err := m.ipSetProvider.Get()
 	if err != nil {
+		logger.Info("failed to get matching IP set", zap.Error(err))
+
 		return fmt.Errorf("failed to get matching IP set: %w", err)
 	}
 
+	logger.Debug("resolved host IP set", zap.Int("ip-count", len(hostIPSet)), zap.Strings("ips", maps.Keys(hostIPSet)))
+
 	existingMappingForHostPort := m.hostPortToMapping[hostPort]
 	if existingMappingForHostPort != nil && existingMappingForHostPort.svcName != svcName {
+		logger.Warn("host port conflict: already registered to another service",
+			zap.String("conflicting-svc", existingMappingForHostPort.svcName),
+		)
+
 		return fmt.Errorf("host port %d is already registered to another service: %s", hostPort, existingMappingForHostPort.svcName)
 	}
 
 	existingMappingForService := m.svcNameToPortMapping[svcName]
 	if existingMappingForService != nil {
+		logger.Debug("existing mapping found",
+			zap.Int("existing-host-port", existingMappingForService.hostPort),
+			zap.Int("existing-svc-port", existingMappingForService.svcPort),
+			zap.Int("existing-ip-count", len(existingMappingForService.hostIPSet)),
+			zap.Strings("existing-ips", maps.Keys(existingMappingForService.hostIPSet)),
+		)
+
 		if existingMappingForService.hostPort == hostPort &&
 			existingMappingForService.svcPort == svcPort &&
 			reflect.DeepEqual(existingMappingForService.hostIPSet, hostIPSet) {
-			m.logger.Info("nothing to do, no changes in mapping")
+			logger.Debug("nothing to do, no changes in mapping")
 
 			return nil
 		}
+
+		logger.Debug("existing mapping changed, replacing it")
 
 		m.removeNoLock(svcName)
 	}
@@ -114,21 +131,32 @@ func (m *Mapper) Add(svcName string, hostPort, svcPort int) error {
 	}
 
 	// use an error level logger to avoid spamming the logs with upstream health check failure warnings
-	lbLogger := logger.With(zap.String("component", "loadbalancer")).WithOptions(zap.IncreaseLevel(zap.ErrorLevel))
+	lbLogger := logger.Named("loadbalancer").WithOptions(zap.IncreaseLevel(zap.ErrorLevel))
 
 	lb, err := m.loadBalancerController.New(lbLogger)
 	if err != nil {
+		logger.Info("failed to create loadbalancer", zap.Error(err))
+
 		return fmt.Errorf("failed to create loadbalancer: %w", err)
 	}
 
 	for ip := range hostIPSet {
-		if err = lb.AddRoute(net.JoinHostPort(ip, strconv.Itoa(hostPort)),
-			slices.Values([]string{net.JoinHostPort(svcName, strconv.Itoa(svcPort))}),
+		listenAddr := net.JoinHostPort(ip, strconv.Itoa(hostPort))
+		upstreamAddr := net.JoinHostPort(svcName, strconv.Itoa(svcPort))
+
+		logger.Debug("add loadbalancer route", zap.String("listen-addr", listenAddr), zap.String("upstream-addr", upstreamAddr))
+
+		if err = lb.AddRoute(listenAddr,
+			slices.Values([]string{upstreamAddr}),
 			upstream.WithHealthcheckTimeout(time.Second),
 		); err != nil {
+			logger.Info("failed to add loadbalancer route", zap.String("listen-addr", listenAddr), zap.String("upstream-addr", upstreamAddr), zap.Error(err))
+
 			return fmt.Errorf("failed to add route to loadbalancer: %w", err)
 		}
 	}
+
+	logger.Debug("start loadbalancer")
 
 	if err = lb.Start(); err != nil {
 		logger.Info("failed to start loadbalancer, attempt to stop it")
@@ -140,6 +168,8 @@ func (m *Mapper) Add(svcName string, hostPort, svcPort int) error {
 
 		return fmt.Errorf("failed to start loadbalancer: %w", err)
 	}
+
+	logger.Debug("loadbalancer started")
 
 	mapping := &portMapping{
 		hostIPSet: hostIPSet,
@@ -164,16 +194,31 @@ func (m *Mapper) removeNoLock(svcName string) {
 
 	mapping := m.svcNameToPortMapping[svcName]
 	if mapping == nil {
+		logger.Debug("mapping does not exist")
+
 		return
 	}
 
+	logger.Debug("mapping found, removing",
+		zap.Int("host-port", mapping.hostPort),
+		zap.Int("svc-port", mapping.svcPort),
+		zap.Int("ip-count", len(mapping.hostIPSet)),
+		zap.Strings("ips", maps.Keys(mapping.hostIPSet)),
+	)
+
 	if mapping.lb != nil {
+		logger.Debug("close loadbalancer")
+
 		if err := mapping.lb.Close(); err != nil {
 			logger.Info("error on closing load balancer", zap.Error(err))
 		} else {
+			logger.Debug("wait for loadbalancer to stop")
+
 			// successfully closed, wait for the proxy to finish running
 			if err = mapping.lb.Wait(); err != nil {
 				logger.Info("error on waiting for load balancer to close", zap.Error(err))
+			} else {
+				logger.Debug("loadbalancer stopped")
 			}
 		}
 	}

--- a/internal/ip/tracker.go
+++ b/internal/ip/tracker.go
@@ -79,6 +79,8 @@ func NewTracker(refresher SetRefresher, clientProvider ClientProvider, serviceHa
 
 // Run runs the Tracker. It blocks until the context is canceled.
 func (t *Tracker) Run(ctx context.Context) error {
+	t.logger.Info("starting IP tracker", zap.Duration("period", t.period))
+
 	ticker := t.clock.Ticker(t.period)
 	defer ticker.Stop()
 
@@ -100,8 +102,12 @@ func (t *Tracker) handleChanges(ctx context.Context) error {
 
 	ipSet, err := t.ipSetRefresher.Refresh()
 	if err != nil {
+		t.logger.Info("failed to refresh IP set", zap.Error(err))
+
 		return fmt.Errorf("failed to refresh IP set: %w", err)
 	}
+
+	t.logger.Debug("refreshed IP set", zap.Int("old-ip-count", len(t.ipSet)), zap.Int("new-ip-count", len(ipSet)))
 
 	if reflect.DeepEqual(ipSet, t.ipSet) {
 		t.logger.Debug("IP set didn't change, skip refresh")
@@ -111,18 +117,26 @@ func (t *Tracker) handleChanges(ctx context.Context) error {
 
 	t.ipSet = ipSet
 
-	t.logger.Info("detected changes on IP set, refresh mappings")
+	t.logger.Info("detected changes on IP set, refresh mappings", zap.Int("ip-count", len(ipSet)))
 
 	svcList := &corev1.ServiceList{}
 
 	if err = t.clientProvider.GetClient().List(ctx, svcList); err != nil {
+		t.logger.Info("failed to list services for IP refresh", zap.Error(err))
+
 		return fmt.Errorf("failed to list Services: %w", err)
 	}
+
+	t.logger.Debug("listed services for IP refresh", zap.Int("service-count", len(svcList.Items)))
 
 	var errs error
 
 	for _, svc := range svcList.Items {
+		t.logger.Debug("refreshing service mapping", zap.String("svc-name", svc.Name+"."+svc.Namespace))
+
 		if err = t.serviceHandler.Handle(&svc); err != nil {
+			t.logger.Info("failed to refresh service mapping", zap.String("svc-name", svc.Name+"."+svc.Namespace), zap.Error(err))
+
 			errs = multierror.Append(errs, fmt.Errorf("failed to handle Service %s/%s: %w", svc.Namespace, svc.Name, err))
 		}
 	}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,10 +35,11 @@ var _ reconcile.Reconciler = &Reconciler{}
 type Reconciler struct {
 	serviceHandler ServiceHandler
 	clientProvider ClientProvider
+	logger         *zap.Logger
 }
 
 // New returns a new Reconciler.
-func New(clientProvider ClientProvider, serviceHandler ServiceHandler) (*Reconciler, error) {
+func New(clientProvider ClientProvider, serviceHandler ServiceHandler, logger *zap.Logger) (*Reconciler, error) {
 	if serviceHandler == nil {
 		return nil, fmt.Errorf("serviceHandler must not be nil")
 	}
@@ -46,19 +48,30 @@ func New(clientProvider ClientProvider, serviceHandler ServiceHandler) (*Reconci
 		return nil, fmt.Errorf("clientProvider must not be nil")
 	}
 
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
 	return &Reconciler{
 		serviceHandler: serviceHandler,
 		clientProvider: clientProvider,
+		logger:         logger,
 	}, nil
 }
 
 // Reconcile implements reconcile.Reconciler.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	svc := &corev1.Service{}
 	svcName := request.Name + "." + request.Namespace
+	logger := r.logger.With(zap.String("svc-name", svcName), zap.Stringer("request", request.NamespacedName))
+
+	logger.Debug("reconcile request")
+
+	svc := &corev1.Service{}
 
 	err := r.clientProvider.GetClient().Get(ctx, request.NamespacedName, svc)
 	if errors.IsNotFound(err) {
+		logger.Debug("service not found in cache, handling as delete")
+
 		if err = r.serviceHandler.HandleDelete(svcName); err != nil {
 			return reconcile.Result{}, err
 		}
@@ -67,12 +80,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if err != nil {
+		logger.Info("failed to fetch service", zap.Error(err))
+
 		return reconcile.Result{}, fmt.Errorf("could not fetch Service: %w", err)
 	}
 
+	logger.Debug("service fetched",
+		zap.String("resource-version", svc.ResourceVersion),
+		zap.Int("annotation-count", len(svc.GetAnnotations())),
+		zap.Int("port-count", len(svc.Spec.Ports)),
+	)
+
 	if err = r.serviceHandler.Handle(svc); err != nil {
+		logger.Info("failed to handle service", zap.Error(err))
+
 		return reconcile.Result{}, fmt.Errorf("failed to handle Service: %w", err)
 	}
+
+	logger.Debug("service handled")
 
 	return reconcile.Result{}, nil
 }

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -48,13 +49,15 @@ func (m *mockServiceHandler) HandleDelete(svcName string) error {
 func TestReconcilerCreate(t *testing.T) {
 	t.Parallel()
 
-	_, err := reconciler.New(nil, &mockServiceHandler{})
+	logger := zaptest.NewLogger(t)
+
+	_, err := reconciler.New(nil, &mockServiceHandler{}, logger)
 	assert.ErrorContains(t, err, "clientProvider must not be nil")
 
-	_, err = reconciler.New(&mockClientProvider{}, nil)
+	_, err = reconciler.New(&mockClientProvider{}, nil, logger)
 	assert.ErrorContains(t, err, "serviceHandler must not be nil")
 
-	rec, err := reconciler.New(&mockClientProvider{}, &mockServiceHandler{})
+	rec, err := reconciler.New(&mockClientProvider{}, &mockServiceHandler{}, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, rec)
 }
@@ -75,7 +78,7 @@ func TestReconcilerReconcile(t *testing.T) {
 
 	serviceHandler := &mockServiceHandler{}
 
-	rec, err := reconciler.New(clientProvider, serviceHandler)
+	rec, err := reconciler.New(clientProvider, serviceHandler, zaptest.NewLogger(t))
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3)

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -74,7 +74,11 @@ func (s *Handler) Handle(svc *corev1.Service) error {
 
 	logger := s.logger.With(zap.String("svc-name", svcName))
 
-	logger.Debug("handle Service")
+	logger.Debug("handle Service",
+		zap.String("type", string(svc.Spec.Type)),
+		zap.Int("annotation-count", len(svc.GetAnnotations())),
+		zap.Int("port-count", len(svc.Spec.Ports)),
+	)
 
 	annotationIsSet := false
 	hostPortStr := ""
@@ -89,7 +93,7 @@ func (s *Handler) Handle(svc *corev1.Service) error {
 	}
 
 	if !annotationIsSet {
-		logger.Debug("annotation is not set on service")
+		logger.Debug("annotation is not set on service, remove mapping if it exists")
 
 		s.ipMapper.Remove(svcName)
 
@@ -100,12 +104,16 @@ func (s *Handler) Handle(svc *corev1.Service) error {
 
 	hostPort, err := strconv.Atoi(hostPortStr)
 	if err != nil {
+		logger.Info("failed to parse host port annotation, leave existing mapping unchanged", zap.String("value", hostPortStr), zap.Error(err))
+
 		return fmt.Errorf("invalid host port %q: %w", hostPortStr, err)
 	}
 
+	logger.Debug("parsed host port", zap.Int("host-port", hostPort))
+
 	for _, portRange := range s.disallowedPortRanges {
 		if portRange.Contains(hostPort) {
-			logger.Warn("disallowed host port", zap.Int("host-port", hostPort), zap.String("disallowed-port-range", portRange.String()))
+			logger.Warn("disallowed host port, remove mapping if it exists", zap.Int("host-port", hostPort), zap.String("disallowed-port-range", portRange.String()))
 
 			s.ipMapper.Remove(svcName)
 
@@ -117,8 +125,10 @@ func (s *Handler) Handle(svc *corev1.Service) error {
 		return port.Protocol == corev1.ProtocolTCP
 	})
 
+	logger.Debug("filtered service ports", zap.Int("tcp-port-count", len(svcTCPPorts)), zap.Any("ports", svc.Spec.Ports))
+
 	if len(svcTCPPorts) == 0 {
-		logger.Debug("no TCP ports on Service")
+		logger.Debug("no TCP ports on Service, remove mapping if it exists")
 
 		s.ipMapper.Remove(svcName)
 
@@ -128,12 +138,18 @@ func (s *Handler) Handle(svc *corev1.Service) error {
 	svcPort := int(svcTCPPorts[0].Port)
 
 	if len(svcTCPPorts) > 1 {
-		logger.Info("more than one TCP port on Service, using the first one", zap.Int("svc-port", svcPort))
+		logger.Debug("more than one TCP port on Service, using the first one", zap.Int("svc-port", svcPort), zap.String("port-name", svcTCPPorts[0].Name))
 	}
 
+	logger.Debug("register service mapping", zap.Int("host-port", hostPort), zap.Int("svc-port", svcPort))
+
 	if err = s.ipMapper.Add(svcName, hostPort, svcPort); err != nil {
+		logger.Info("failed to register service mapping", zap.Int("host-port", hostPort), zap.Int("svc-port", svcPort), zap.Error(err))
+
 		return fmt.Errorf("failed to register host port: %w", err)
 	}
+
+	logger.Debug("service mapping registered", zap.Int("host-port", hostPort), zap.Int("svc-port", svcPort))
 
 	return nil
 }
@@ -144,7 +160,7 @@ func (s *Handler) HandleDelete(svcName string) error {
 		return fmt.Errorf("svcName must not be empty")
 	}
 
-	s.logger.Debug("handle Service delete", zap.String("svc-name", svcName))
+	s.logger.Debug("handle Service delete, remove mapping if it exists", zap.String("svc-name", svcName))
 
 	s.ipMapper.Remove(svcName)
 


### PR DESCRIPTION
Add more contextual debug logs to be able to troubleshoot issues like stale cache, inconsistent reads etc.

Replace loggers with a `"component"` field to instead use `logger.Named("component-name")` to have hierarchical names in different components, and to avoid duplicate fields in JSON logs.