### PR TITLE
feat: support signing released images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-22T10:19:03Z by kres 41939c6.
+# Generated on 2026-05-05T07:40:58Z by kres 1762ab2.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -109,7 +109,7 @@ jobs:
           make release-notes
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # version: v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # version: v3.0.0
         with:
           body_path: _out/RELEASE_NOTES.md
           draft: "true"

--- a/.github/workflows/slack-notify-ci-failure.yaml
+++ b/.github/workflows/slack-notify-ci-failure.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-22T10:19:03Z by kres 41939c6.
+# Generated on 2026-05-05T07:40:58Z by kres 1762ab2.
 
 "on":
   workflow_run:
@@ -18,7 +18,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'pull_request'
     steps:
       - name: Slack Notify
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # version: v3.0.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # version: v3.0.2
         with:
           method: chat.postMessage
           payload: |

--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-22T10:19:03Z by kres 41939c6.
+# Generated on 2026-05-05T07:40:58Z by kres 1762ab2.
 
 "on":
   workflow_run:
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo pull_request_number=$(gh pr view -R ${{ github.repository }} ${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }} --json number --jq .number) >> $GITHUB_OUTPUT
       - name: Slack Notify
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # version: v3.0.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # version: v3.0.2
         with:
           method: chat.postMessage
           payload: |

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -29,3 +29,28 @@ spec:
 kind: service.CodeCov
 spec:
   targetThreshold: 40
+---
+kind: auto.CustomSteps
+spec:
+  steps:
+    - name: sign-images
+      toplevel: true
+---
+kind: custom.Step
+name: sign-images
+spec:
+  makefile:
+    enabled: true
+    phony: true
+    variables:
+      - name: IMAGE_SIGNER_IMAGE
+        defaultValue: ghcr.io/siderolabs/image-signer:v0.3.2
+    script:
+      - |
+        @test -n "$$GITHUB_TOKEN" || { echo "GITHUB_TOKEN must be set"; exit 1; }
+        @TMP=$$(mktemp -d) && trap 'rm -rf $$TMP' EXIT && \
+          printf '{"auths":{"ghcr.io":{"username":"x","password":"%s"}}}' "$$GITHUB_TOKEN" > $$TMP/config.json && \
+          docker run --rm -p 127.0.0.1:8585:8585 \
+            -v $$TMP:/dc:ro -e DOCKER_CONFIG=/dc \
+            $(IMAGE_SIGNER_IMAGE) sign --timeout=15m \
+            $(REGISTRY_AND_USERNAME)/kube-service-exposer:$(IMAGE_TAG)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,16 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-22T10:19:03Z by kres 41939c6.
+# Generated on 2026-05-05T07:40:58Z by kres 1762ab2.
 
 ARG TOOLCHAIN=scratch
 
-FROM ghcr.io/siderolabs/ca-certificates:v1.12.0 AS image-ca-certificates
+FROM ghcr.io/siderolabs/ca-certificates:v1.13.0 AS image-ca-certificates
 
-FROM ghcr.io/siderolabs/fhs:v1.12.0 AS image-fhs
+FROM ghcr.io/siderolabs/fhs:v1.13.0 AS image-fhs
 
 # runs markdownlint
-FROM docker.io/oven/bun:1.3.11-alpine AS lint-markdown
+FROM docker.io/oven/bun:1.3.13-alpine AS lint-markdown
 WORKDIR /src
 RUN bun i markdownlint-cli@0.48.0 sentences-per-line@0.5.2
 COPY .markdownlint.json .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-22T10:19:03Z by kres 41939c6.
+# Generated on 2026-05-05T12:52:25Z by kres 1762ab2.
 
 # common variables
 
@@ -21,15 +21,15 @@ USERNAME ?= siderolabs
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
 PROTOBUF_GO_VERSION ?= 1.36.11
 GRPC_GO_VERSION ?= 1.6.1
-GRPC_GATEWAY_VERSION ?= 2.28.0
+GRPC_GATEWAY_VERSION ?= 2.29.0
 VTPROTOBUF_VERSION ?= 0.6.0
-GOIMPORTS_VERSION ?= 0.43.0
+GOIMPORTS_VERSION ?= 0.44.0
 GOMOCK_VERSION ?= 0.6.0
 DEEPCOPY_VERSION ?= v0.5.8
 GOLANGCILINT_VERSION ?= v2.11.4
 GOFUMPT_VERSION ?= v0.9.2
 GO_VERSION ?= 1.26.2
-DIS_VULNCHECK_VERSION ?= v0.0.0-20260408104044-a7a2dc044240
+DIS_VULNCHECK_VERSION ?= v0.0.0-20260409114749-05440f84fe69
 GO_BUILDFLAGS ?=
 GO_BUILDTAGS ?= ,
 GO_LDFLAGS ?=
@@ -80,6 +80,10 @@ COMMON_ARGS += --build-arg=GOFUMPT_VERSION="$(GOFUMPT_VERSION)"
 COMMON_ARGS += --build-arg=DIS_VULNCHECK_VERSION="$(DIS_VULNCHECK_VERSION)"
 COMMON_ARGS += --build-arg=TESTPKGS="$(TESTPKGS)"
 TOOLCHAIN ?= docker.io/golang:1.26-alpine
+
+# extra variables
+
+IMAGE_SIGNER_IMAGE ?= ghcr.io/siderolabs/image-signer:v0.3.2
 
 # help menu
 
@@ -251,6 +255,16 @@ lint-fmt: lint-golangci-lint-fmt  ## Run all linter formatters and fix up the so
 .PHONY: image-kube-service-exposer
 image-kube-service-exposer:  ## Builds image for kube-service-exposer.
 	@$(MAKE) registry-$@ IMAGE_NAME="kube-service-exposer"
+
+.PHONY: sign-images
+sign-images:
+	@test -n "$$GITHUB_TOKEN" || { echo "GITHUB_TOKEN must be set"; exit 1; }
+	@TMP=$$(mktemp -d) && trap 'rm -rf $$TMP' EXIT && \
+	  printf '{"auths":{"ghcr.io":{"username":"x","password":"%s"}}}' "$$GITHUB_TOKEN" > $$TMP/config.json && \
+	  docker run --rm -p 127.0.0.1:8585:8585 \
+	    -v $$TMP:/dc:ro -e DOCKER_CONFIG=/dc \
+	    $(IMAGE_SIGNER_IMAGE) sign --timeout=15m \
+	    $(REGISTRY_AND_USERNAME)/kube-service-exposer:$(IMAGE_TAG)
 
 .PHONY: rekres
 rekres:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,33 @@ spec:
 
 The service will be exposed on port `12345` on all nodes,
 on the IP addresses within the CIDRs specified (all addresses by default).
+When the annotation is just a port number, the first TCP service port is used.
+
+The annotation also accepts a comma-separated list of entries.
+Each entry is either a bare host port or a `host-port:service-port` pair,
+where the service port can be a number or a name:
+
+```yaml
+kube-service-exposer.sidero.dev/port: "30080,30443:8080,30444:https"
+```
+
+This exposes `30080` (the first TCP port), `30443` (service port `8080`),
+and `30444` (the port named `https`).
 
 **Note**: `kube-service-exposer` only works with TCP.
 Services without any TCP ports will be ignored.
-If a Service contains multiple TCP ports, kube-service-exposer pick the first one.
+Non-TCP entries in the annotation are skipped.
+
+## Signing images
+
+Released container images are signed with [cosign](https://docs.sigstore.dev/) keyless.
+Talos verifies these signatures via an
+[ImageVerificationConfig](https://www.talos.dev/v1.13/security/verifying-image-signatures/).
+
+To sign a release, set `GITHUB_TOKEN` with `write:packages` scope and run:
+
+```bash
+GITHUB_TOKEN=$(gh auth token) make sign-images TAG=v0.X.Y
+```
+
+A browser opens for Google authentication. To backfill an older release, pass its tag instead.


### PR DESCRIPTION
Add a make target to sign released container images with cosign keyless. The signer authenticates the operator via Google OAuth and impersonates the Talos production release manager service account, producing signatures verifiable by Talos image verification rules for the Sidero registry namespace.

Past releases have also been signed manually: v0.1.0, v0.1.1, v0.1.2, v0.1.3, v0.1.4, v0.2.0, v0.2.1, v0.3.0.